### PR TITLE
Fix hook name to match documentation

### DIFF
--- a/jeev/module.py
+++ b/jeev/module.py
@@ -286,7 +286,7 @@ class Module(object):
         """
         self._loaded_callbacks.append(f)
 
-    def unload(self, f):
+    def unloaded(self, f):
         """
             Register a function to be called before the module is unloaded.
         """


### PR DESCRIPTION
Should be 'unloaded' to match what's in the api documentation.
